### PR TITLE
rfk tweaks to get tests running

### DIFF
--- a/components/service/nimbus/build.gradle
+++ b/components/service/nimbus/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation Dependencies.uniffi_nimbus_forUnitTests
     testImplementation Dependencies.androidx_test_core
     testImplementation Dependencies.androidx_test_junit
+    testImplementation Dependencies.testing_robolectric
 }
 
 apply from: '../../../publish.gradle'

--- a/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/NimbusTest.kt
+++ b/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/NimbusTest.kt
@@ -7,7 +7,12 @@ package mozilla.components.service.nimbus
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import mozilla.components.service.nimbus.NimbusInternalAPI.Companion.getLanguageFromLocale
 import mozilla.components.service.nimbus.NimbusInternalAPI.Companion.getLocaleTag
 import org.junit.Assert.assertEquals
@@ -25,15 +30,22 @@ class NimbusTest {
 
     @Test
     fun `test Nimbus initialize`() {
-        runBlocking {
+        runBlocking { withTimeout(3000L) { suspendCancellableCoroutine<Unit> { cont ->
             try {
                 Nimbus.initialize(context) { experiments ->
-                    assertTrue(experiments.count() > 0)
+                    try {
+                        // Uncomment this to test awaiting of the callback
+                        // assert(false)
+                        assertTrue(experiments.count() > 0)
+                        cont.resume(Unit)
+                    } catch (e: Throwable) {
+                        cont.resumeWithException(e)
+                    }
                 }
-            } catch (e: UnsatisfiedLinkError) {
-                assert(false)
+            } catch (e: Throwable) {
+                cont.resumeWithException(e)
             }
-        }
+        }}}
     }
 
     @Test


### PR DESCRIPTION
@travis79 I was trying to reproduce your test-related errors from https://github.com/mozilla-mobile/android-components/pull/8261, and had to make the following tweaks to get the tests running successfully for me. Figured I might as well push them in case they're more broadly useful.